### PR TITLE
refactor(server.js): added gzip compression to files served by server

### DIFF
--- a/apps/AppShell/package.json
+++ b/apps/AppShell/package.json
@@ -33,6 +33,7 @@
     "browserslist": "^4.18.1",
     "camelcase": "^6.2.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
+    "compression": "^1.7.4",
     "css-loader": "^6.5.1",
     "css-minimizer-webpack-plugin": "^3.2.0",
     "custom-event-polyfill": "^1.0.7",

--- a/apps/AppShell/src/server/index.ts
+++ b/apps/AppShell/src/server/index.ts
@@ -3,12 +3,14 @@ import path from 'path'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {helmetGuard, htmlMiddleware, httpLogger} from '@next/middlewares'
+import compression from 'compression'
 import express from 'express'
 
 import {renderMiddleware} from './middleware/render'
 
 const publicPath = path.join(__dirname, '/public')
 const app = express()
+app.use(compression())
 
 // app.use(httpLogger(process.env.NODE_ENV === 'development'))
 app.use(httpLogger(false))

--- a/apps/MFE/Footer/package.json
+++ b/apps/MFE/Footer/package.json
@@ -34,6 +34,7 @@
     "bfj": "^7.0.2",
     "browserslist": "^4.18.1",
     "camelcase": "^6.2.1",
+    "compression": "^1.7.4",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "css-loader": "^6.5.1",
     "css-minimizer-webpack-plugin": "^3.2.0",

--- a/apps/MFE/Footer/src/server/index.ts
+++ b/apps/MFE/Footer/src/server/index.ts
@@ -4,6 +4,7 @@ import path from 'path'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {helmetGuard, htmlMiddleware, httpLogger, prerenderMiddleware} from '@next/middlewares'
 import {json} from 'body-parser'
+import compression from 'compression'
 import express from 'express'
 
 import federationStats from '../remote-entry/federation-stats.json'
@@ -12,6 +13,7 @@ import {renderMiddleware} from './middleware/render'
 
 const publicPath = path.join(__dirname, '/public')
 const app = express()
+app.use(compression())
 
 // app.use(httpLogger(process.env.NODE_ENV === 'development'))
 app.use(httpLogger(false))

--- a/apps/MFE/Header/package.json
+++ b/apps/MFE/Header/package.json
@@ -35,6 +35,7 @@
     "browserslist": "^4.18.1",
     "camelcase": "^6.2.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
+    "compression": "^1.7.4",
     "css-loader": "^6.5.1",
     "css-minimizer-webpack-plugin": "^3.2.0",
     "custom-event-polyfill": "^1.0.7",

--- a/apps/MFE/Header/src/server/index.ts
+++ b/apps/MFE/Header/src/server/index.ts
@@ -4,6 +4,7 @@ import path from 'path'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {helmetGuard, htmlMiddleware, httpLogger} from '@next/middlewares'
 import {json} from 'body-parser'
+import compression from 'compression'
 import express from 'express'
 
 import {prerenderMiddleware} from './middleware/prerender'
@@ -11,6 +12,7 @@ import {renderMiddleware} from './middleware/render'
 
 const publicPath = path.join(__dirname, '/public')
 const app = express()
+app.use(compression())
 
 // app.use(httpLogger(process.env.NODE_ENV === 'development'))
 app.use(httpLogger(false))

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "browserslist": "^4.18.1",
     "camelcase": "^6.2.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
+    "compression": "^1.7.4",
     "css-loader": "^6.5.1",
     "css-minimizer-webpack-plugin": "^3.2.0",
     "custom-event-polyfill": "^1.0.7",
@@ -168,5 +169,8 @@
       "skipScope": false,
       "defaultScope": "*"
     }
+  },
+  "devDependencies": {
+    "@types/compression": "^1.7.2"
   }
 }


### PR DESCRIPTION
Just gzip for now. Brotli not available for `compression` currently, but will probably be added soon (there are several PRs).